### PR TITLE
Do not use a custom base path for assets in production

### DIFF
--- a/cover-api/config/packages/prod/framework.yaml
+++ b/cover-api/config/packages/prod/framework.yaml
@@ -1,3 +1,0 @@
-framework:
-    assets:
-        base_path: '%app.path.prefix%'


### PR DESCRIPTION
Now that we combine Symfony and static files in the same application both locally and in production we use the default root path for assets.

Consequently no special config is needed in production.
