### PR TITLE
Update agency/profile usage

### DIFF
--- a/importers/src/Service/OpenPlatform/SearchService.php
+++ b/importers/src/Service/OpenPlatform/SearchService.php
@@ -91,18 +91,18 @@ class SearchService
      */
     public function search(string $identifier, string $type, string $agencyId = '', string $profile = '', bool $refresh = false): Material
     {
-        // Check if input parameters are set, if not fallback to default configuration.
-        $agencyId = empty($agencyId) ? $this->agency : $agencyId;
-        if (empty($profile)) {
-            if (empty($agencyId)) {
-                // Both profile and agency is not set explicit. So profile should
-                // be the one configured.
-                $profile = $this->searchProfile;
-            } else {
-                // Agency have been set but no profile to default to "opac" profile, which
-                // all libraries should have.
-                $profile = self::FALLBACK_PROFILE;
-            }
+        if (empty($agencyId) && empty($profile)) {
+            // If no parameter is set then fallback to default configuration.
+            $agencyId = $this->agency;
+            $profile = $this->searchProfile;
+        } elseif (empty($profile)) {
+            // Agency have been set but no profile to default to "opac" profile, which
+            // all libraries should have.
+            $profile = self::FALLBACK_PROFILE;
+        } elseif (empty($agencyId)) {
+            // Profile is set but not agency then assume we can use the default
+            // agency.
+            $agencyId = $this->agency;
         }
 
         try {


### PR DESCRIPTION
The current implementation would search using the default agency and the fallback profile if no agency and profile is set.

This is problematic because messages by default will not have either set. In these cases the system should search using both default agency and profile. This ensures that the agency/profile combination DK-775100/coverservice is used which will yield the widest possible search. This is required for us to map ids from sources (either PID, ISBN or Faust) to the remaining id types. This will make covers searchable from all interfaces.

Update the logic for selecting agency and profile so that the default agency and profile is used by default.