### PR TITLE
Add admin password to local OpenSearch services

### DIFF
--- a/cover-api/docker-compose.yml
+++ b/cover-api/docker-compose.yml
@@ -71,6 +71,7 @@ services:
       - name=opensearch-node1
       - discovery.type=single-node
       - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=ihBDx2atXZjpgYWaEy9c
     volumes:
       - opensearch-data1:/usr/share/opensearch/data
     ports:

--- a/importers/docker-compose.yml
+++ b/importers/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       - name=opensearch-node2
       - discovery.type=single-node
       - plugins.security.disabled=true
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=ihBDx2atXZjpgYWaEy9c
     volumes:
       - opensearch-data2:/usr/share/opensearch/data
     ports:


### PR DESCRIPTION
Recent versions of OpenSearch will not start without a a password. Apparently it also needs to be a strong one so add a random one.

In practice it is not used. We have disabled the security plugin.