### PR TITLE
Ensure vendors use UTC timezone for sources

### DIFF
--- a/importers/src/Service/VendorService/UploadService/UploadServiceVendorService.php
+++ b/importers/src/Service/VendorService/UploadService/UploadServiceVendorService.php
@@ -238,13 +238,14 @@ class UploadServiceVendorService implements VendorServiceImporterInterface
             $this->em->persist($image);
 
             // Set source entity information.
+            $timezone = new \DateTimeZone('UTC');
             $source->setMatchType($type)
                 ->setMatchId($identifier)
                 ->setVendor($this->vendorCoreService->getVendor($this->getVendorId()))
-                ->setDate(new \DateTime())
+                ->setDate(new \DateTime('now', $timezone))
                 ->setOriginalFile($item->getUrl())
                 ->setOriginalContentLength($item->getSize())
-                ->setOriginalLastModified(new \DateTime())
+                ->setOriginalLastModified(new \DateTime('now', $timezone))
                 ->setImage($image);
             $this->em->persist($source);
 

--- a/importers/src/Service/VendorService/VendorCoreService.php
+++ b/importers/src/Service/VendorService/VendorCoreService.php
@@ -218,6 +218,7 @@ final class VendorCoreService
         // Load batch from database to enable updates.
         $sources = $sourceRepo->findByMatchIdList($identifierType, $batch, $vendor);
 
+        $timezone = new \DateTimeZone('UTC');
         foreach ($batch as $identifier => $imageUrl) {
             if (array_key_exists($identifier, $sources)) {
                 /* @var Source $source */
@@ -226,7 +227,7 @@ final class VendorCoreService
                     $source->setMatchType($identifierType)
                         ->setMatchId($identifier)
                         ->setVendor($vendor)
-                        ->setDate(new \DateTime())
+                        ->setDate(new \DateTime('now', $timezone))
                         ->setOriginalFile($imageUrl);
                     $updatedIdentifiers[] = $identifier;
                 }
@@ -235,7 +236,7 @@ final class VendorCoreService
                 $source->setMatchType($identifierType)
                     ->setMatchId($identifier)
                     ->setVendor($vendor)
-                    ->setDate(new \DateTime())
+                    ->setDate(new \DateTime('now', $timezone))
                     ->setOriginalFile($imageUrl);
                 $this->em->persist($source);
                 $insertedIdentifiers[] = $identifier;


### PR DESCRIPTION
When the image validator service tries to determine if a cover image has been updated it tries to compare last-modified values for source and image.

The default image validator will use UTC by default for images but sources are created with whatever timezone is configured in the environment. If these do not match then images will be considered updated even though they are not.

To ensure that sources are generated with the same timezone no matter what has been configured in the environment we hardcode source dates to also use UTC.

An alternate approach would be to make it a configurable variable but that would be a more complex change.