### PR TITLE
Include sources with 0 searches in updates

### DIFF
--- a/importers/src/Service/VendorService/VendorCoreService.php
+++ b/importers/src/Service/VendorService/VendorCoreService.php
@@ -222,7 +222,7 @@ final class VendorCoreService
             if (array_key_exists($identifier, $sources)) {
                 /* @var Source $source */
                 $source = $sources[$identifier];
-                if ($source->getDate() >= $withUpdatesDate && self::UPDATE_COVER_LIMIT === $source->getSearches()->count()) {
+                if ($source->getDate() >= $withUpdatesDate && self::UPDATE_COVER_LIMIT >= $source->getSearches()->count()) {
                     $source->setMatchType($identifierType)
                         ->setMatchId($identifier)
                         ->setVendor($vendor)


### PR DESCRIPTION
#### Description

Currently we only consider sources which have a single associated search. Searches are associated with covers in the IndexMessageHandler but errors may occur before this stage. This might includes failure to search the material, failure to download the file etc.

In such situations we want to retry the import process automatically. Consequently we consider all sources with a search count equal - or lower - than the limit (1) as updated.
