### PR TITLE
Ensure nullable type for ImageUrls are boolean - not string

### DIFF
--- a/cover-api/public/spec.yaml
+++ b/cover-api/public/spec.yaml
@@ -192,7 +192,7 @@ components:
         url:
           type: string
           format: url
-          nullable: 'true'
+          nullable: true
           example: 'https://res.cloudinary.com/dandigbib/image/upload/v1543609481/bogportalen.dk/9788702246841.jpg'
         format:
           type: string

--- a/cover-api/src/Api/Dto/ImageUrl.php
+++ b/cover-api/src/Api/Dto/ImageUrl.php
@@ -24,7 +24,7 @@ final class ImageUrl
      *         "openapi_context"={
      *              "type"="string",
      *              "format"="url",
-     *              "nullable"="true",
+     *              "nullable"=true,
      *              "example"="https://res.cloudinary.com/dandigbib/image/upload/v1543609481/bogportalen.dk/9788702246841.jpg"
      *          }
      *     }


### PR DESCRIPTION
#### Description

It is invalid and makes schema validation fail for third party clients using the schema for code generation.
