### PR TITLE
Reduce disk size for select applications

### DIFF
--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -343,7 +343,7 @@ upload-api:
   size: M
 
   # The size of the persistent disk of the application (in MB).
-  disk: 4096
+  disk: 5120
 
   build:
     flavor: composer

--- a/.platform/applications.yaml
+++ b/.platform/applications.yaml
@@ -15,7 +15,7 @@ cover-api:
   size: XL
 
   # The size of the persistent disk of the application (in MB).
-  disk: 1024
+  disk: 512
 
   build:
     flavor: composer
@@ -117,7 +117,7 @@ importers:
   size: S
 
   # The size of the persistent disk of the application (in MB).
-  disk: 1028
+  disk: 512
 
   build:
     flavor: composer

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -74,6 +74,6 @@ searchopen:
   # the CLI will return an error.
   type: opensearch:2
   # The disk attribute is the size of the persistent disk (in MB) allocated to the service.
-  disk: 2048
+  disk: 1536
   # How many CPU and memory resources to allocate to the service.
   size: 2XL


### PR DESCRIPTION
#### Description

Pratice shows that the cover api ad imports applications do not need the 1GB they are currently allocated.

We can use this elsewhere.
