### PR TITLE
Disabling identifier search in OpenPlatform

### DIFF
--- a/.github/workflows/importers_pr.yaml
+++ b/.github/workflows/importers_pr.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           php-version: ${{ matrix.php}}
           coverage: none
+          extensions: redis-6.0.2
 
       - name: Get composer cache directory
         id: composer-cache
@@ -74,6 +75,7 @@ jobs:
         with:
           php-version: ${{ matrix.php}}
           coverage: none
+          extensions: redis-6.0.2
 
       - name: Get composer cache directory
         id: composer-cache


### PR DESCRIPTION
#### Description

Previously we tried to look up alternate identifiers for the single identifier received in relation to a cover for a vendor. This allowed a cover to be found through different means (PID, Faust, ISBN etc.) depending on the requirements of the client. We used OpenPlatform to perform this mapping.

OpenPlatform has been shut down. This causes the process to fail with a low level uncaught exception causing all further processing of the cover to stop.

To work around this problem we do a simple 1-to-1 mapping from the data contained within the message to a corresponding material which can be indexed.

This will allow processing to continue and covers will at least be retrievable through the ids from their original sources.
